### PR TITLE
Fixed a bug in queryIterable API when called with no options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unpublished
+
+**Fixed**
+
+* Fixed a bug in queryIterable API when called with no options.
+
 ## 5.3.0 = 2022-02-18
 
 **Added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 **Fixed**
 
-* Fixed a bug in queryIterable API when called with no options.
+* Fixed a bug where queryIterable API was throwing TypeError when called
+without *opt* parameter.
 
 ## 5.3.0 = 2022-02-18
 

--- a/lib/nosql_client.js
+++ b/lib/nosql_client.js
@@ -1175,10 +1175,13 @@ class NoSQLClient extends NoSQLClientImpl {
             opt = Object.assign({}, opt);
             delete opt.continuationKey;
         }
-
+        
         do {
             const result = await this.query(stmt, opt);
             yield result;
+            if (opt == null) {
+                opt = {};
+            }
             opt.continuationKey = result.continuationKey;
         } while(opt.continuationKey);
     }

--- a/test/unit/query.js
+++ b/test/unit/query.js
@@ -446,6 +446,8 @@ limit of ${testCase.maxMemFail}`);
 function getQueryOpts(test, q, tc) {
     return [
         undefined,
+        //Because we alternate execution of query() and queryIterable(), this
+        //will ensure both are tested when no options are provided.
         undefined,
         {
             timeout: 12000


### PR DESCRIPTION
Please review as this bug prevents calling queryIterable with no options passed and its a small fix.
