### PR TITLE
Added new region codes: AGA BOG VAP NAP AVZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Unpublished
 
+**Added**
+
 * Support for query array_collect and count(distinct) operators.
+* Cloud only: Added OCI region codes: AGA BOG VAP NAP AVZ
 
 ## 5.5.0 - 2023-08-17
 

--- a/lib/region.js
+++ b/lib/region.js
@@ -61,6 +61,14 @@ const Realms = {
     OC20: {
         realmId: 'oc20',
         secondLevelDomain: 'oraclecloud20.com'
+    },
+    OC22: {
+        realmId: 'oc22',
+        secondLevelDomain: 'oraclecloud22.com'
+    },
+    OC24: {
+        realmId: 'oc24',
+        secondLevelDomain: 'oraclecloud24.com'
     }
 };
 
@@ -291,6 +299,11 @@ Region.US_SANJOSE_1 = new Region('us-sanjose-1', 'sjc', Realms.OC1);
 Region.US_CHICAGO_1 = new Region('us-chicago-1', 'ord', Realms.OC1);
 
 /**
+ * Realm: OC1, US West (Salt Lake)
+ */
+Region.US_SALTLAKE_2 = new Region('us-saltlake-2', 'aga', Realms.OC1);
+
+/**
  * Realm: OC1, Canada Southeast (Toronto)
  */
 Region.CA_TORONTO_1 = new Region('ca-toronto-1', 'yyz', Realms.OC1);
@@ -301,6 +314,11 @@ Region.CA_TORONTO_1 = new Region('ca-toronto-1', 'yyz', Realms.OC1);
 Region.CA_MONTREAL_1 = new Region('ca-montreal-1', 'yul', Realms.OC1);
 
 /**
+ * Realm: OC1, Colombia (Bogota)
+ */
+Region.SA_BOGOTA_1 = new Region('sa-bogota-1', 'bog', Realms.OC1);
+
+/**
  * Realm: OC1, Brazil East (Sao Paulo)
  */
 Region.SA_SAOPAULO_1 = new Region('sa-saopaulo-1', 'gru', Realms.OC1);
@@ -309,6 +327,11 @@ Region.SA_SAOPAULO_1 = new Region('sa-saopaulo-1', 'gru', Realms.OC1);
  * Realm: OC1, Chile (Santiago)
  */
 Region.SA_SANTIAGO_1 = new Region('sa-santiago-1', 'scl', Realms.OC1);
+
+/**
+ * Realm: OC1, Chile (Valparaiso)
+ */
+Region.SA_VALPARAISO_1 = new Region('sa-valparaiso-1', 'vap', Realms.OC1);
 
 /**
  * Realm: OC1, Brazil (Vinhedo)
@@ -441,6 +464,16 @@ Region.EU_MADRID_2 = new Region('eu-madrid-2', 'vll', Realms.OC19);
  * Realm: OC20, Jovanovac (Serbia)
  */
 Region.EU_JOVANOVAC_1 = new Region('eu-jovanovac-1', 'beg', Realms.OC20);
+
+/**
+ * Realm: OC22, Italy dedicated (Rome)
+ */
+Region.EU_DCC_ROME_1 = new Region('eu-dcc-rome-1', 'nap', Realms.OC22);
+
+/**
+ * Realm: OC24, Switzerland dedicated (Zurich)
+ */
+Region.EU_DCC_ZURICH_1 = new Region('eu-dcc-zurich-1', 'avz', Realms.OC24);
 
 
 Region.seal();


### PR DESCRIPTION
"us-saltlake-2", "aga", OC1
"sa-bogota-1", "bog", OC1
"sa-valparaiso-1", "vap", OC1
"eu-dcc-rome-1", "nap", OC22
"eu-dcc-zurich-1", "avz", OC24